### PR TITLE
Fix logic in Scavenger's Rucksack

### DIFF
--- a/Items/Boss/ExtraEquipment.cs
+++ b/Items/Boss/ExtraEquipment.cs
@@ -244,7 +244,7 @@ namespace ThinkInvisible.TinkersSatchel {
                         master.inventory.SetEquipment(stashedEquipment.Dequeue(), master.inventory.activeEquipmentSlot);
 					}
 				}
-			} else if(!isStopped) {
+			} else {
 				isStopped = false;
 				stationaryStopwatch = 0f;
 				shuffleStopwatch = 0f;


### PR DESCRIPTION
Currently there's an issue where the Scavenger's Rucksack won't properly reset itself, because of an erroneous check that `isStopped` is false before setting to false. The consequence of this is a little hard to fully explain, but basically, once you've started cycling through equipment, it'll never exit the state of trying to cycle through equipment - it'll always increment and check `shuffleStopwatch` (rather than `stationaryStopwatch`) when you're stopped, and never actually reset it when you start moving again.

Simply removing this extra `if(!isStopped)` check fixes the logic here, causing the item to properly reset its state whenever you start moving again. This kind of check was never necessary in the first place, because the `else` block will only ever run when you're moving anyway.