### PR TITLE
Fix no items dropped by boss if one player dies

### DIFF
--- a/Items/Lunar/MountainToken.cs
+++ b/Items/Lunar/MountainToken.cs
@@ -98,6 +98,7 @@ namespace ThinkInvisible.TinkersSatchel {
                     foreach(var nu in NetworkUser.readOnlyInstancesList) {
                         if(!nu.isParticipating) continue;
                         var body = nu.GetCurrentBody();
+                        if(!body) continue;
                         if(body.TryGetComponent<MountainTokenTracker>(out var mtt)) {
                             extraRewardsSingular += mtt.Stacks;
                             mtt.Unset();


### PR DESCRIPTION
Fixes #78 - A dead player has no body so there's a NullReferenceException. This check is present elsewhere in the file, just seems to have been forgotten here.